### PR TITLE
SJSU-1009: Fixed aspect ratio issue

### DIFF
--- a/front_end/src/App.css
+++ b/front_end/src/App.css
@@ -47,7 +47,8 @@ img.shop-logo {
 /* 'Browse By Category' page CSS */
 .category-card-img {
   width: 100%;
-  height: 35vh;
+  height: 25vh;
+  object-fit: contain;
   background-color: white;
 }
 
@@ -155,7 +156,8 @@ img.shop-logo {
 /* Product Card component CSS */
 .product-card-img {
   width: 100%;
-  height: 30vh;
+  height: 25vh;
+  object-fit: contain;
 }
 
 .product-card-name {


### PR DESCRIPTION
What I did:
I fixed the aspect ratio issue by changing the set height of each product card (still relative to browser height) and adding the 'object-fit: contain' line in app.css. Now all images shown in ProductCards will retain their original aspect ratio and will not appear stretched. Unless the original images are already stretched.

Here's what ProductCards and BrowseByCategory look like now:
![products](https://user-images.githubusercontent.com/18728903/47610860-65632e80-da14-11e8-8951-437cd067166e.JPG)

![category](https://user-images.githubusercontent.com/18728903/47610861-6eec9680-da14-11e8-9627-ccc9a5355efb.JPG)
